### PR TITLE
feat(schema): [sc 2922] HTTP request validation using openapi v3

### DIFF
--- a/nozl/core/core.go
+++ b/nozl/core/core.go
@@ -166,7 +166,7 @@ func handleLimiter(c *core) nats.Handler {
 
 func handleFilter(c *core) nats.Handler {
 	return func(msg *eventstream.Message) {
-		_, err := schema.ValidateOpenAPIV3Schema(msg)
+		err := schema.ValidateOpenAPIV3Schema(msg)
 		if err != nil {
 			shared.Logger.Error(err.Error())
 		}

--- a/nozl/core/core.go
+++ b/nozl/core/core.go
@@ -168,6 +168,8 @@ func handleFilter(c *core) nats.Handler {
 	return func(msg *eventstream.Message) {
 		err := schema.ValidateOpenAPIV3Schema(msg)
 		if err != nil {
+			// TODO: Return error to sender and break function here. Decide later
+			// if this message should be sent to dead letter queue
 			shared.Logger.Error(err.Error())
 		}
 		if c.filterLimiterAllow(msg) {

--- a/nozl/core/core.go
+++ b/nozl/core/core.go
@@ -86,7 +86,7 @@ func (c *core) Init() {
 	c.initKVStore(shared.MsgWaitListKV, "")
 	c.initKVStore(shared.MsgLogKV, "")
 	c.initKVStore(shared.TenantAPIKV, "")
-	c.initKVStore(shared.SchemaKv, "")
+	c.initKVStore(shared.SchemaKV, "")
 }
 
 func (c *core) initKVStore(bucketName string, bucketDescription string) {

--- a/nozl/core/core.go
+++ b/nozl/core/core.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nats-io/nats-server/v2/nozl/eventstream"
 	"github.com/nats-io/nats-server/v2/nozl/filter"
 	"github.com/nats-io/nats-server/v2/nozl/rate"
+	"github.com/nats-io/nats-server/v2/nozl/schema"
 	"github.com/nats-io/nats-server/v2/nozl/service"
 	"github.com/nats-io/nats-server/v2/nozl/shared"
 	"github.com/nats-io/nats-server/v2/nozl/tenant"
@@ -165,6 +166,10 @@ func handleLimiter(c *core) nats.Handler {
 
 func handleFilter(c *core) nats.Handler {
 	return func(msg *eventstream.Message) {
+		_, err := schema.ValidateOpenAPIV3Schema(msg)
+		if err != nil {
+			shared.Logger.Error(err.Error())
+		}
 		if c.filterLimiterAllow(msg) {
 			shared.Logger.Info(msg.ID,
 				zap.String("Subject", "Filter"),

--- a/nozl/schema/schema.go
+++ b/nozl/schema/schema.go
@@ -38,19 +38,19 @@ func ParseOpenApiV3Schema(serviceID string, specFile []byte) error {
 	for pathKey, pathValue := range doc.Paths {
 
 		if pathValue.Get != nil {
-			AddSchemaToKVStore(serviceID, pathKey, "get", pathValue.Get)
+			AddSchemaToKVStore(serviceID, pathKey, "GET", pathValue.Get)
 		}
 		if pathValue.Post != nil {
-			AddSchemaToKVStore(serviceID, pathKey, "post", pathValue.Post)
+			AddSchemaToKVStore(serviceID, pathKey, "POST", pathValue.Post)
 		}
 		if pathValue.Put != nil {
-			AddSchemaToKVStore(serviceID, pathKey, "put", pathValue.Put)
+			AddSchemaToKVStore(serviceID, pathKey, "PUT", pathValue.Put)
 		}
 		if pathValue.Patch != nil {
-			AddSchemaToKVStore(serviceID, pathKey, "patch", pathValue.Patch)
+			AddSchemaToKVStore(serviceID, pathKey, "PATCH", pathValue.Patch)
 		}
 		if pathValue.Delete != nil {
-			AddSchemaToKVStore(serviceID, pathKey, "delete", pathValue.Delete)
+			AddSchemaToKVStore(serviceID, pathKey, "DELETE", pathValue.Delete)
 		}
 	}
 
@@ -107,7 +107,7 @@ func ValidateOpenAPIV3Schema(msg *eventstream.Message) error {
 	jsonData, _ := json.Marshal(&msgBody)
 	formData := strings.NewReader(string(jsonData))
 
-	httpReq, err := http.NewRequest("POST", schemaValid.Path, formData)
+	httpReq, err := http.NewRequest(schemaValid.HttpMethod, schemaValid.Path, formData)
 	headers := make(map[string]string)
 	headers["Content-Type"] = "application/x-www-form-urlencoded"
 	for key, val := range headers {

--- a/nozl/schema/schema.go
+++ b/nozl/schema/schema.go
@@ -76,7 +76,7 @@ func ParseOpenApiV3Schema(serviceID string, specFile []byte) error {
 }
 
 func ValidateOpenAPIV3Schema(msg *eventstream.Message) (bool, error) {
-	schemaValid, err := GetMsgValidSchema(msg)
+	schemaValid, err := GetMsgRefSchema(msg)
 	if err != nil {
 		shared.Logger.Error(err.Error())
 		return false, err
@@ -88,7 +88,7 @@ func ValidateOpenAPIV3Schema(msg *eventstream.Message) (bool, error) {
 	return false, nil
 }
 
-func GetMsgValidSchema(msg *eventstream.Message) (Schema, error) {
+func GetMsgRefSchema(msg *eventstream.Message) (Schema, error) {
 	schemaKv, err := eventstream.Eventstream.RetreiveKeyValStore(shared.SchemaKV)
 	if err != nil {
 		shared.Logger.Error(err.Error())

--- a/nozl/schema/schema.go
+++ b/nozl/schema/schema.go
@@ -106,15 +106,6 @@ func ValidateOpenAPIV3Schema(msg *eventstream.Message) error {
 	ctx := context.Background()
 	jsonData, _ := json.Marshal(&msgBody)
 	formData := strings.NewReader(string(jsonData))
-	//baseUrl := "https://api.twilio.com"
-	//rgx, _ := regexp.Compile("{AccountSid}")
-	//ep := rgx.ReplaceAllString(schemaValid.Path, "AC9f560ea30baaaf8013e4e44284eb6768")
-	//data := url.Values{}
-
-	//data.Add("To", +923244253153)
-	//data.Add("Body", "helloworld")
-	//payload := strings.NewReader("Body=Hello%20World!&To=%2B923214930471&From=%2B19034598701&edfgsgd=sdfds")
-	//payload := strings.NewReader(data.Encode())
 
 	httpReq, err := http.NewRequest("POST", schemaValid.Path, formData)
 	headers := make(map[string]string)

--- a/nozl/schema/schema.go
+++ b/nozl/schema/schema.go
@@ -31,7 +31,7 @@ func ParseOpenApiV3Schema(serviceID string, specFile []byte) error {
 	}
 
 	var schemaList map[string]Schema
-	schemaKv, _ := eventstream.Eventstream.RetreiveKeyValStore(shared.ServiceKV)
+	schemaKv, _ := eventstream.Eventstream.RetreiveKeyValStore(shared.SchemaKV)
 	entry, err := schemaKv.Get(serviceID)
 
 	if err != nil {

--- a/nozl/schema/schema.go
+++ b/nozl/schema/schema.go
@@ -69,3 +69,7 @@ func ParseOpenApiV3Schema(serviceID string, specFile []byte) error {
 
 	return nil
 }
+
+func CheckOpenAPIV3SchemaIsValid(msg eventstream.Message) (bool, error) {
+	return false, nil
+}

--- a/nozl/schema/schema.go
+++ b/nozl/schema/schema.go
@@ -48,13 +48,17 @@ func ParseOpenApiV3Schema(serviceID string, specFile []byte) error {
 
 		if pathValue.Get != nil {
 			schemaList[pathValue.Get.OperationID] = addSchema(pathKey, "get", pathValue.Get)
-		} else if pathValue.Post != nil {
+		}
+		if pathValue.Post != nil {
 			schemaList[pathValue.Post.OperationID] = addSchema(pathKey, "post", pathValue.Post)
-		} else if pathValue.Put != nil {
+		}
+		if pathValue.Put != nil {
 			schemaList[pathValue.Put.OperationID] = addSchema(pathKey, "put", pathValue.Put)
-		} else if pathValue.Patch != nil {
+		}
+		if pathValue.Patch != nil {
 			schemaList[pathValue.Patch.OperationID] = addSchema(pathKey, "patch", pathValue.Patch)
-		} else if pathValue.Delete != nil {
+		}
+		if pathValue.Delete != nil {
 			schemaList[pathValue.Delete.OperationID] = addSchema(pathKey, "delete", pathValue.Delete)
 		}
 	}

--- a/nozl/schema/schema.go
+++ b/nozl/schema/schema.go
@@ -59,6 +59,7 @@ func ParseOpenApiV3Schema(serviceID string, specFile []byte) error {
 
 func MakeOptionalFieldsNullable(operation *openapi3.Operation) error {
 	if operation.RequestBody != nil {
+		// TODO: This needs to be undated to also handle other headers
 		ReqBodySchema := operation.RequestBody.Value.Content["application/x-www-form-urlencoded"].Schema.Value
 		RequiredParams := ReqBodySchema.Required
 		ReqBodyParams := ReqBodySchema.Properties
@@ -109,6 +110,7 @@ func ValidateOpenAPIV3Schema(msg *eventstream.Message) error {
 
 	httpReq, err := http.NewRequest(schemaValid.HttpMethod, schemaValid.Path, formData)
 	headers := make(map[string]string)
+	// TODO: Header should be dynamically set
 	headers["Content-Type"] = "application/x-www-form-urlencoded"
 	for key, val := range headers {
 		httpReq.Header.Add(key, val)

--- a/nozl/shared/constants.go
+++ b/nozl/shared/constants.go
@@ -18,7 +18,7 @@ const (
 	TenantAPIKV       string = "TenanatApiKey"
 	UserKV            string = "User"
 	MsgWaitListKV     string = "MsgWaitList"
-	SchemaKv          string = "schema"
+	SchemaKV          string = "schema"
 	MsgLogKV          string = "MsgLog"
 	SenderPhoneNumber string = "+19034598701"
 )


### PR DESCRIPTION
- Update Schema KV Store name to match other KV store names convention
- Add Schema Validation function in filter function
- Update storage to Open API spec file so that each operation is stored separately in the KV store with key being in the format:
"<service_id>-<operation_id>"
- While adding the Reference Schema to the KV store, the optional fields in the Request Body are set to nullable=True manually
