### PR TITLE
Feature/sc 2928/generic message body

### DIFF
--- a/nozl/core/core.go
+++ b/nozl/core/core.go
@@ -121,13 +121,14 @@ func (c *core) Send(msg *eventstream.Message) {
 
 // TODO: Get limiter values from API.
 func (c *core) filterLimiterAllow(msg *eventstream.Message) bool {
-	if val, exists := c.Filters[msg.ReqBody.UserID]; exists {
+	userID := msg.ReqBody["user_id"].(string)
+	if val, exists := c.Filters[userID]; exists {
 		return val.Allow()
 	}
 
-	c.RegisterFilter(msg.ReqBody.UserID, shared.UserTokenRate, shared.UserBucketSize)
+	c.RegisterFilter(userID, shared.UserTokenRate, shared.UserBucketSize)
 
-	return c.Filters[msg.ReqBody.UserID].Allow()
+	return c.Filters[userID].Allow()
 }
 
 func (c *core) RegisterFilter(userID string, tokenRate int, bucketSize int) uuid.UUID {

--- a/nozl/core/core.go
+++ b/nozl/core/core.go
@@ -121,13 +121,13 @@ func (c *core) Send(msg *eventstream.Message) {
 
 // TODO: Get limiter values from API.
 func (c *core) filterLimiterAllow(msg *eventstream.Message) bool {
-	if val, exists := c.Filters[msg.Body.UserID]; exists {
+	if val, exists := c.Filters[msg.ReqBody.UserID]; exists {
 		return val.Allow()
 	}
 
-	c.RegisterFilter(msg.Body.UserID, shared.UserTokenRate, shared.UserBucketSize)
+	c.RegisterFilter(msg.ReqBody.UserID, shared.UserTokenRate, shared.UserBucketSize)
 
-	return c.Filters[msg.Body.UserID].Allow()
+	return c.Filters[msg.ReqBody.UserID].Allow()
 }
 
 func (c *core) RegisterFilter(userID string, tokenRate int, bucketSize int) uuid.UUID {

--- a/nozl/eventstream/handler.go
+++ b/nozl/eventstream/handler.go
@@ -11,8 +11,8 @@ import (
 )
 
 func SendMessageHandler(ctx echo.Context) error {
-	var body Body
-	msg := NewMessage("", "", body)
+	var reqBody ReqBody
+	msg := NewMessage("", "", reqBody)
 
 	if err := ctx.Bind(&msg); err != nil {
 		return ctx.JSON(http.StatusInternalServerError, echo.Map{
@@ -29,7 +29,7 @@ func SendMessageHandler(ctx echo.Context) error {
 
 	Eventstream.PublishEncodedMessage("Filter", msg)
 
-	msgStatus := <- MessageStatus
+	msgStatus := <-MessageStatus
 
 	return ctx.JSON(http.StatusOK, echo.Map{
 		"message": msgStatus,

--- a/nozl/eventstream/message.go
+++ b/nozl/eventstream/message.go
@@ -7,14 +7,16 @@ import (
 )
 
 type (
+	ReqBody map[string]interface{}
+
 	Message struct {
-		ID          string `json:"id"`
-		ServiceID   string `json:"service_id"`
-		OperationID string `json:"operation_id"`
-		TenantID    string `json:"tenant_id"`
-		CreatedAt   string `json:"created_at"`
-		SentAt      string `json:"sent_at"`
-		ReqBody     Body   `json:"req_body"`
+		ID          string  `json:"id"`
+		ServiceID   string  `json:"service_id"`
+		OperationID string  `json:"operation_id"`
+		TenantID    string  `json:"tenant_id"`
+		CreatedAt   string  `json:"created_at"`
+		SentAt      string  `json:"sent_at"`
+		ReqBody     ReqBody `json:"req_body"`
 	}
 
 	Body struct {
@@ -24,7 +26,7 @@ type (
 	}
 )
 
-func NewMessage(serviceID string, operationID string, body Body) *Message {
+func NewMessage(serviceID string, operationID string, body ReqBody) *Message {
 	return &Message{
 		ID:          uuid.New().String(),
 		ServiceID:   serviceID,

--- a/nozl/eventstream/message.go
+++ b/nozl/eventstream/message.go
@@ -14,7 +14,7 @@ type (
 		TenantID    string `json:"tenant_id"`
 		CreatedAt   string `json:"created_at"`
 		SentAt      string `json:"sent_at"`
-		Body        Body   `json:"body"`
+		ReqBody     Body   `json:"req_body"`
 	}
 
 	Body struct {
@@ -29,7 +29,7 @@ func NewMessage(serviceID string, operationID string, body Body) *Message {
 		ID:          uuid.New().String(),
 		ServiceID:   serviceID,
 		OperationID: operationID,
-		Body:        body,
+		ReqBody:     body,
 		CreatedAt:   time.Now().Format("2006-01-02 15:04:05"),
 	}
 }

--- a/nozl/eventstream/message.go
+++ b/nozl/eventstream/message.go
@@ -18,12 +18,6 @@ type (
 		SentAt      string  `json:"sent_at"`
 		ReqBody     ReqBody `json:"req_body"`
 	}
-
-	Body struct {
-		UserID      string `json:"user_id"`
-		Payload     string `json:"payload"`
-		Destination string `json:"destination"`
-	}
 )
 
 func NewMessage(serviceID string, operationID string, body ReqBody) *Message {
@@ -33,13 +27,5 @@ func NewMessage(serviceID string, operationID string, body ReqBody) *Message {
 		OperationID: operationID,
 		ReqBody:     body,
 		CreatedAt:   time.Now().Format("2006-01-02 15:04:05"),
-	}
-}
-
-func NewBody(userID string, payload string, dest string) *Body {
-	return &Body{
-		UserID:      userID,
-		Payload:     payload,
-		Destination: dest,
 	}
 }

--- a/nozl/schema/schema.go
+++ b/nozl/schema/schema.go
@@ -61,8 +61,12 @@ func ParseOpenApiV3Schema(serviceID string, specFile []byte) error {
 
 func MakeOptionalFieldsNullable(operation *openapi3.Operation) error {
 	if operation.RequestBody != nil {
-		// TODO: This needs to be undated to also handle other headers
-		ReqBodySchema := operation.RequestBody.Value.Content["application/x-www-form-urlencoded"].Schema.Value
+		var contentType string
+		for key, _ := range operation.RequestBody.Value.Content {
+			contentType = key
+		}
+
+		ReqBodySchema := operation.RequestBody.Value.Content[contentType].Schema.Value
 		RequiredParams := ReqBodySchema.Required
 		ReqBodyParams := ReqBodySchema.Properties
 

--- a/nozl/schema/schema.go
+++ b/nozl/schema/schema.go
@@ -101,8 +101,6 @@ func ValidateOpenAPIV3Schema(msg *eventstream.Message) error {
 	openapi3.SchemaErrorDetailsDisabled = true
 
 	msgBody := msg.ReqBody
-	fmt.Println(schemaValid)
-	fmt.Println(msgBody)
 
 	ctx := context.Background()
 	jsonData, _ := json.Marshal(&msgBody)

--- a/nozl/schema/schema.go
+++ b/nozl/schema/schema.go
@@ -100,7 +100,7 @@ func ValidateOpenAPIV3Schema(msg *eventstream.Message) error {
 	}
 	openapi3.SchemaErrorDetailsDisabled = true
 
-	msgBody := msg.Body
+	msgBody := msg.ReqBody
 	fmt.Println(schemaValid)
 	fmt.Println(msgBody)
 

--- a/nozl/schema/schema.go
+++ b/nozl/schema/schema.go
@@ -67,12 +67,18 @@ func MakeOptionalFieldsNullable(operation *openapi3.Operation) error {
 		ReqBodyParams := ReqBodySchema.Properties
 
 		for key, val := range ReqBodyParams {
+			MakeRefsEmpty(val) // This is being done because when marshalling SchemaRef, it only marshals field "Ref"
 			if stringInSlice(key, RequiredParams) == false {
 				val.Value.Nullable = true
 			}
 		}
 	}
 
+	return nil
+}
+
+func MakeRefsEmpty(schemaRef *openapi3.SchemaRef) error {
+	schemaRef.Ref = ""
 	return nil
 }
 

--- a/nozl/service/twilio.go
+++ b/nozl/service/twilio.go
@@ -14,9 +14,9 @@ func (s *Service) SendMsgTwilio(msg *eventstream.Message) error {
 	})
 
 	params := &twilioApi.CreateMessageParams{}
-	params.SetBody(msg.ReqBody.Payload)
+	params.SetBody(msg.ReqBody["body"].(string))
 	params.SetFrom(shared.SenderPhoneNumber)
-	params.SetTo(msg.ReqBody.Destination)
+	params.SetTo(msg.ReqBody["to"].(string))
 
 	resp, err := client.Api.CreateMessage(params)
 	if err != nil {

--- a/nozl/service/twilio.go
+++ b/nozl/service/twilio.go
@@ -28,3 +28,7 @@ func (s *Service) SendMsgTwilio(msg *eventstream.Message) error {
 
 	return nil
 }
+
+func (s *Service) SendMsgTwilioAPI(msg *eventstream.Message) error {
+	return nil
+}

--- a/nozl/service/twilio.go
+++ b/nozl/service/twilio.go
@@ -14,9 +14,9 @@ func (s *Service) SendMsgTwilio(msg *eventstream.Message) error {
 	})
 
 	params := &twilioApi.CreateMessageParams{}
-	params.SetBody(msg.Body.Payload)
+	params.SetBody(msg.ReqBody.Payload)
 	params.SetFrom(shared.SenderPhoneNumber)
-	params.SetTo(msg.Body.Destination)
+	params.SetTo(msg.ReqBody.Destination)
 
 	resp, err := client.Api.CreateMessage(params)
 	if err != nil {

--- a/nozl/service/twilio.go
+++ b/nozl/service/twilio.go
@@ -14,9 +14,9 @@ func (s *Service) SendMsgTwilio(msg *eventstream.Message) error {
 	})
 
 	params := &twilioApi.CreateMessageParams{}
-	params.SetBody(msg.ReqBody["body"].(string))
+	params.SetBody(msg.ReqBody["Body"].(string))
 	params.SetFrom(shared.SenderPhoneNumber)
-	params.SetTo(msg.ReqBody["to"].(string))
+	params.SetTo(msg.ReqBody["To"].(string))
 
 	resp, err := client.Api.CreateMessage(params)
 	if err != nil {


### PR DESCRIPTION
Link to story: https://app.shortcut.com/breu/story/2928/generic-message-body
- Replace custom Message struct's body with generic map
- On uploading OAPI schema for the 1st time
  - replace all Schema properties' Ref values with empty string
  - dynamically retrieve header value and use it to set schema's properties nullable fields as true