### PR TITLE
refactor(): [sc-2994] Move nozl init in nats main package

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -40,14 +40,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/avast/retry-go/v4"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
 	"github.com/nats-io/nuid"
 
 	"github.com/nats-io/nats-server/v2/logger"
-	"github.com/nats-io/nats-server/v2/nozl"
-	"github.com/nats-io/nats-server/v2/nozl/core"
 )
 
 const (
@@ -1959,39 +1956,6 @@ func (s *Server) Start() {
 	// Wait for clients.
 	if !opts.DontListen {
 		s.AcceptLoop(clientListenReady)
-	}
-
-	if opts.BackendHTTPPort != _EMPTY_ {
-		rf := opts.ReplicationFactor
-		s.Noticef("replication factor %d", rf)
-
-		nozl.PreSetupNozl(opts.Port)
-		core.Core.InitSubscriptions()
-
-		retryCb := func() error {
-			peers := s.ActivePeers()
-			isLeader := s.JetStreamIsLeader()
-			isClustered := s.JetStreamIsClustered()
-
-			log := fmt.Sprintf("peers: %d leader: %t cluster mode: %t", len(peers), isLeader, isClustered)
-			s.Noticef(log)
-
-			if (len(peers) > 2 && isLeader) || !isClustered {
-				core.Core.InitStores(rf)
-				core.Core.InitConf()
-				return nil
-			}
-
-			return errors.New(log)
-		}
-
-		err := retry.Do(retryCb, retry.Attempts(5), retry.Delay(2*time.Second))
-
-		if err != nil {
-			s.Noticef(err.Error())
-		}
-
-		nozl.SetupNozl(opts.BackendHTTPPort)
 	}
 }
 


### PR DESCRIPTION
-Nozl in currently being initialized in the server package. This prevents us from using Server from inside the Nozl package due to cyclical imports
-To fix this, Nozl initialization is being moved to the main package. This will allow us to manipulate the server from inside Nozl