### PR TITLE
feat(service): [sc 3007] custom label based filtering

### DIFF
--- a/nozl/core/core.go
+++ b/nozl/core/core.go
@@ -284,7 +284,7 @@ func (c *core) LogSentMessage(msg *eventstream.Message) error {
 }
 
 func (c *core) getServiceFromMsg(msg *eventstream.Message) (*service.Service, error) {
-	currService := service.NewService("", "", "")
+	currService := service.NewService("", "", "", "")
 
 	kv, err := eventstream.Eventstream.RetreiveKeyValStore(shared.ServiceKV)
 	if err != nil {

--- a/nozl/core/core.go
+++ b/nozl/core/core.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -100,17 +101,16 @@ func (c *core) Send(msg *eventstream.Message) {
 }
 
 // TODO: Get limiter values from API.
-func (c *core) filterLimiterAllow(msg *eventstream.Message) bool {
-	userID := msg.ReqBody["user_id"].(string)
+func (c *core) filterLimiterAllow(msg *eventstream.Message, filterOnID string) bool {
 	kv, err := eventstream.Eventstream.RetreiveKeyValStore(shared.FilterLimiterKV)
 	if err != nil {
 		shared.Logger.Error(err.Error())
 		return false
 	}
 
-	flRaw, err := kv.Get(userID)
+	flRaw, err := kv.Get(filterOnID)
 	if err != nil {
-		c.RegisterFilter(kv, userID)
+		c.RegisterFilter(kv, filterOnID)
 		return true
 	}
 
@@ -119,7 +119,7 @@ func (c *core) filterLimiterAllow(msg *eventstream.Message) bool {
 
 	allow := fl.Allow()
 	flUpdated, err := json.Marshal(fl)
-	_, err = kv.Put(userID, flUpdated)
+	_, err = kv.Put(filterOnID, flUpdated)
 	if err != nil {
 		shared.Logger.Error(err.Error())
 		return false
@@ -159,7 +159,7 @@ func (c *core) mainLimiterWait(msg *eventstream.Message) error {
 	return nil
 }
 
-func (c *core) RegisterFilter(kv nats.KeyValue, userID string) {
+func (c *core) RegisterFilter(kv nats.KeyValue, filterOnID string) {
 	confKeyAll := []string{shared.UserTokenRate, shared.UserBucketSize}
 	confMap := eventstream.GetMultValKVstore(shared.ConfigKV, confKeyAll)
 	TokenRate, _ := strconv.Atoi(string(confMap[shared.UserTokenRate]))
@@ -173,7 +173,7 @@ func (c *core) RegisterFilter(kv nats.KeyValue, userID string) {
 		return
 	}
 
-	_, err = kv.Put(userID, newFilterRaw)
+	_, err = kv.Put(filterOnID, newFilterRaw)
 	if err != nil {
 		shared.Logger.Error(err.Error())
 		return
@@ -208,7 +208,25 @@ func (c *core) handleFilter(msg *eventstream.Message) {
 		shared.Logger.Error(err.Error())
 		return
 	}
-	if c.filterLimiterAllow(msg) {
+	serv, err := c.getServiceFromMsg(msg)
+	if err != nil {
+		eventstream.MessageFilterAllow <- &eventstream.MessageFilterStatus{
+			Allow:  false,
+			Reason: string(err.Error()),
+		}
+		shared.Logger.Error(err.Error())
+		return
+	}
+	filterOnID, exists := msg.ReqBody[serv.FilterOn]
+	if exists == false {
+		eventstream.MessageFilterAllow <- &eventstream.MessageFilterStatus{
+			Allow:  false,
+			Reason: fmt.Sprintf("Incorrect filter_on field name. Correct filter_on field name for this service: %s", serv.FilterOn),
+		}
+		return
+	}
+	filterOnIDStr := filterOnID.(string)
+	if c.filterLimiterAllow(msg, filterOnIDStr) {
 		shared.Logger.Info(msg.ID,
 			zap.String("Subject", "Filter"),
 			zap.String("Status", "Allowed"),

--- a/nozl/schema/schema.go
+++ b/nozl/schema/schema.go
@@ -238,7 +238,7 @@ func GetMsgRefSchema(msg *eventstream.Message) (*Schema, error) {
 		return nil, err
 	}
 
-	entry, err := schemaKv.Get(fmt.Sprintf("%s-%s", msg.ServiceID, msg.OperationID))
+	entry, err := schemaKv.Get(fmt.Sprintf("%s_%s", msg.ServiceID, msg.OperationID))
 	if err != nil {
 		shared.Logger.Error(err.Error())
 		return nil, err

--- a/nozl/service/handler.go
+++ b/nozl/service/handler.go
@@ -9,11 +9,12 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/nats-io/nats-server/v2/nozl/eventstream"
 	"github.com/nats-io/nats-server/v2/nozl/rate"
+	"github.com/nats-io/nats-server/v2/nozl/schema"
 	"github.com/nats-io/nats-server/v2/nozl/shared"
-	"github.com/nats-io/nats-server/v2/nozl/schema")
+)
 
 func CreateServiceHandler(ctx echo.Context) error {
-	newService := NewService("", "", "")
+	newService := NewService("", "", "", "")
 
 	if err := ctx.Bind(&newService); err != nil {
 		return ctx.JSON(http.StatusInternalServerError, echo.Map{

--- a/nozl/service/service.go
+++ b/nozl/service/service.go
@@ -10,14 +10,16 @@ type (
 		Name       string `json:"name"`
 		AccountSID string `json:"account_sid"`
 		AuthToken  string `json:"auth_token"`
+		FilterOn   string `json:"filter_on"`
 	}
 )
 
-func NewService(name string, accountSID string, authToken string) *Service {
+func NewService(name string, accountSID string, authToken string, filterOn string) *Service {
 	return &Service{
 		ID:         uuid.New().String(),
 		Name:       name,
 		AccountSID: accountSID,
 		AuthToken:  authToken,
+		FilterOn:   filterOn,
 	}
 }

--- a/nozl/testutils/test_utils.go
+++ b/nozl/testutils/test_utils.go
@@ -97,10 +97,10 @@ func RegisterTenant(url string, authToken string) *tenant.Tenant {
 }
 
 func RegisterService(url string, authToken string) *service.Service {
-	svcName:= "twilio"
+	svcName := "twilio"
 	svcAccountSID := "ACe4c8ac5725c5c02c75aec71f53cc69e4"
 	svcAuthToken := "3ffa94991aa2a5c0246800cd1f1a5616"
-	svc := service.NewService(svcName, svcAccountSID, svcAuthToken)
+	svc := service.NewService(svcName, svcAccountSID, svcAuthToken, "")
 	jsonData, err := json.Marshal(svc)
 
 	if err != nil {
@@ -109,7 +109,7 @@ func RegisterService(url string, authToken string) *service.Service {
 	}
 
 	headers := make(map[string]string)
-	headers["Authorization"] = fmt.Sprintf("Bearer %s", authToken) 
+	headers["Authorization"] = fmt.Sprintf("Bearer %s", authToken)
 	resp, err := HTTPRequest(url, "POST", headers, jsonData)
 
 	if err != nil {
@@ -136,13 +136,13 @@ func RegisterService(url string, authToken string) *service.Service {
 func SetFilterLimit(url string, authToken string, filterLimit int) {
 	requestPayload := struct {
 		Limit string `json:"limit"`
-	} {
+	}{
 		Limit: fmt.Sprintf("%d", filterLimit),
 	}
 	jsonData, _ := json.Marshal(&requestPayload)
 	headers := make(map[string]string)
 
-	headers["Authorization"] = fmt.Sprintf("Bearer %s", authToken) 
+	headers["Authorization"] = fmt.Sprintf("Bearer %s", authToken)
 
 	_, err := HTTPRequest(url, "POST", headers, jsonData)
 


### PR DESCRIPTION
Previously filtering was pre-defined on user_id

PR details:
- FilterOn field is added to service struct
- FilterOn field is set during service registration
- When sending a message via nozl, if wrong filterOn field is added to the request body, an error message is sent back

Bug(schema) Fixed:
- Retrieval of schema fixed after naming convention for keys changed in schema KV
